### PR TITLE
Adding NVM to the PATH in a more simple way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8
 ENV NVM_VERSION v0.38.0
 ENV NODE_VERSION 12
-ENV NVM_DIR /usr/local/nvm
 
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
@@ -83,18 +82,16 @@ RUN dpkg-reconfigure openssh-server
 # Install utilitarian packages.
 RUN apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates gcc g++ make
 
-# Install nvm.
-RUN mkdir $NVM_DIR
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash \
+    && echo "\. "/root/.nvm/nvm.sh"" >> /root/.bashrc \
+    && echo "\. "/root/.nvm/bash_completion"" >> /root/.bashrc \
+    && echo "export PATH=~/.nvm/versions/node/v\$NODE_VERSION/bin:$PATH" >> /root/.bashrc
 
 # Install Node 12.
-RUN echo "source $NVM_DIR/nvm.sh && \
+RUN echo "source /root/.nvm/nvm.sh && \
     nvm install $NODE_VERSION && \
     nvm alias default $NODE_VERSION && \
     nvm use default" | bash
-
 # sSMTP
 # note php is configured to use ssmtp, which is configured to send to mail:1025,
 # which is standard configuration for a mailhog/mailhog image with hostname mail.

--- a/README.md
+++ b/README.md
@@ -70,4 +70,26 @@ volumes:
     driver: local
 ```
 
+For our node installation we are using NVM, to be able to use node properly you should execute the following commands:
+```bash
+source /root/.nvm/nvm.sh
+```
+```bash
+echo 'export NVM_DIR="/root/.nvm/"' >> $BASH_ENV
+```
+```bash
+echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+```
+
+As an example, if you use CircleCI, you could load nvm like this:
+```yaml
+- run:
+    name: Load NVM and nodejs.
+    command: |
+      source /root/.nvm/nvm.sh
+      echo 'export NVM_DIR="/root/.nvm/"' >> $BASH_ENV
+      echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+```
+
+
 Note PHP in this build is configured to send mail to a mailhog container, which captures any outgoing mail and exposes a UI on port 8025.


### PR DESCRIPTION
Sorry my first PR didn't work as expected.

##Steps to test:
-  Build the image using : docker build -t kporras07/docker-drupal-nginx:php-7.4.x ./
- The image should be build with out any issues
